### PR TITLE
client scans env variables for token

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,3 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
+
+src/wrapper
+src/index.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * as Flatfile from "./api";
-export { FlatfileClient } from "./Client";
+export { FlatfileClient } from "./wrapper/FlatfileClient";
 export { FlatfileEnvironment } from "./environments";
 export { FlatfileError, FlatfileTimeoutError } from "./errors";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export { FlatfileClient } from "./wrapper/FlatfileClient";
 export { FlatfileEnvironment } from "./environments";
 export { FlatfileError, FlatfileTimeoutError } from "./errors";
 
-export default new FlatfileClient()
+export default new FlatfileClient();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { FlatfileClient } from "./wrapper/FlatfileClient";
+
 export * as Flatfile from "./api";
 export { FlatfileClient } from "./wrapper/FlatfileClient";
 export { FlatfileEnvironment } from "./environments";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,5 @@ export * as Flatfile from "./api";
 export { FlatfileClient } from "./wrapper/FlatfileClient";
 export { FlatfileEnvironment } from "./environments";
 export { FlatfileError, FlatfileTimeoutError } from "./errors";
+
+export default new FlatfileClient()

--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -14,7 +14,7 @@ export declare namespace FlatfileClient {
 export class FlatfileClient extends FernClient {
     private token: string | undefined;
 
-    constructor(options: FlatfileClient.Options) {
+    constructor(options: FlatfileClient.Options = {}) {
         super({
             environment: options.environment,
             token:

--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -21,7 +21,7 @@ export class FlatfileClient extends FernClient {
                 options.token != null
                     ? options.token
                     : () => {
-                          const token = process.env.FLATFILE_API_KEY || process.env.FLATFILE_BEARER_TOKEN;
+                          const token = process?.env?.FLATFILE_API_KEY || process?.env?.FLATFILE_BEARER_TOKEN;
                           if (token == undefined) {
                               throw new Error("FLATFILE_API_KEY and FLATFILE_BEARER_TOKEN were both undefined");
                           }

--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -1,0 +1,32 @@
+import { FlatfileClient as FernClient } from "../Client";
+import * as environments from "../environments";
+import * as core from "../core";
+import * as errors from "../errors";
+import urlJoin from "url-join";
+
+export declare namespace FlatfileClient {
+    interface Options {
+        environment?: environments.FlatfileEnvironment | string;
+        token?: core.Supplier<string>;
+    }
+}
+
+export class FlatfileClient extends FernClient {
+    private token: string | undefined;
+
+    constructor(options: FlatfileClient.Options) {
+        super({
+            environment: options.environment,
+            token:
+                options.token != null
+                    ? options.token
+                    : () => {
+                          const token = process.env.FLATFILE_API_KEY || process.env.FLATFILE_BEARER_TOKEN;
+                          if (token == undefined) {
+                              throw new Error("FLATFILE_API_KEY and FLATFILE_BEARER_TOKEN were both undefined");
+                          }
+                          return token;
+                      },
+        });
+    }
+}


### PR DESCRIPTION
Create a new client that extends the Fern client. If no token is passed in, then the client looks at `FLATFILE_API_KEY`