### PR TITLE
Add check for session storage

### DIFF
--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -38,7 +38,7 @@ const environmentSupplier = () => {
 };
 
 const tokenSupplier = () => {
-    const token = CrossEnvConfig.get("FLATFILE_BEARER_TOKEN");
+    const token = CrossEnvConfig.get("FLATFILE_BEARER_TOKEN") || sessionStorage.getItem('FLATFILE_BEARER_TOKEN');
     if (token == undefined) {
         throw new Error("FLATFILE_BEARER_TOKEN is not undefined");
     }

--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -38,7 +38,7 @@ const environmentSupplier = () => {
 };
 
 const tokenSupplier = () => {
-    const token = CrossEnvConfig.get("FLATFILE_BEARER_TOKEN") || sessionStorage.getItem('FLATFILE_BEARER_TOKEN');
+    const token = CrossEnvConfig.get("FLATFILE_BEARER_TOKEN") || sessionStorage?.getItem('FLATFILE_BEARER_TOKEN');
     if (token == undefined) {
         throw new Error("FLATFILE_BEARER_TOKEN is not undefined");
     }


### PR DESCRIPTION
Embedded flatfile (client-side) needs to also be able to use the authenticated FlatfileClient out of the box and in our implementation we store the api token in session storage. This PR would allow us to use other Flatfile plugins like `plugin-record-hook` the same way server-side Flatfile is used.