### PR TITLE
fixes broken link in the README + NPM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Flatfile Node.js library provides convenient access to the Flatfile API from
 
 ## Documentation
 
-API reference documentation is available [here](https://flatfile.stoplight.io/docs/v10).
+API reference documentation is available [here](https://flatfile.stoplight.io/docs/api).
 
 ## Installation
 


### PR DESCRIPTION
Currently when you route to the link in this page, you get this:
<img width="1061" alt="image" src="https://github.com/FlatFilers/flatfile-node/assets/37881163/2efde622-2639-4205-b88d-7e0e569d82e9">

This updates the link to one that works for that page.