### PR TITLE
Override the `records.insert()` method

### DIFF
--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -29,13 +29,11 @@ export class FlatfileClient extends FernClient {
         });
     }
 
-    /* reference the overridden records client */
     protected _records: Records | undefined;
 
     public get records(): Records {
         return (this._records ??= new Records(this._options));
     }
-
 }
 
 const environmentSupplier = () => {

--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -3,6 +3,7 @@ import * as environments from "../environments";
 import * as core from "../core";
 import urlJoin from "url-join";
 import { CrossEnvConfig } from "@flatfile/cross-env-config";
+import { Records } from "./RecordsClient";
 
 CrossEnvConfig.alias("FLATFILE_API_URL", "AGENT_INTERNAL_URL");
 CrossEnvConfig.alias("FLATFILE_BEARER_TOKEN", "FLATFILE_API_KEY");
@@ -27,6 +28,14 @@ export class FlatfileClient extends FernClient {
             token: options.token ?? tokenSupplier
         });
     }
+
+    /* reference the overridden records client */
+    protected _records: Records | undefined;
+
+    public get records(): Records {
+        return (this._records ??= new Records(this._options));
+    }
+
 }
 
 const environmentSupplier = () => {

--- a/src/wrapper/RecordsClient.ts
+++ b/src/wrapper/RecordsClient.ts
@@ -13,9 +13,9 @@ export class Records extends FernRecords {
      * @throws {@link Flatfile.NotFoundError}
      */
     public async insert(
-        sheetId: Flatfile.SheetId,
-        request: Flatfile.RecordData[],
-        requestOptions?: FernRecords.RequestOptions
+        _sheetId: Flatfile.SheetId,
+        _request: Flatfile.RecordData[],
+        _requestOptions?: FernRecords.RequestOptions
     ): Promise<Flatfile.RecordsResponse> {
         /* add your own implementation of addRecords */
         throw new Error("Unimplemnted");

--- a/src/wrapper/RecordsClient.ts
+++ b/src/wrapper/RecordsClient.ts
@@ -1,0 +1,23 @@
+import { Records as FernRecords } from "../api/resources/records/client/Client";
+import { Flatfile } from "..";
+import * as environments from "../environments";
+import * as core from "../core";
+import * as serializers from "../serialization";
+import urlJoin from "url-join";
+import * as errors from "../errors";
+
+export class Records extends FernRecords {
+    /**
+     * Adds records to a workbook sheet
+     * @throws {@link Flatfile.BadRequestError}
+     * @throws {@link Flatfile.NotFoundError}
+     */
+    public async insert(
+        sheetId: Flatfile.SheetId,
+        request: Flatfile.RecordData[],
+        requestOptions?: FernRecords.RequestOptions
+    ): Promise<Flatfile.RecordsResponse> {
+        /* add your own implementation of addRecords */
+        throw new Error("Unimplemnted");
+    }
+}


### PR DESCRIPTION
This PR shows an example of how to override the `addRecords` method in the SDK. The steps taken were: 

1. Introduce a new file `RecordsClient` which extends the Fern generated Records client. This class will override the `insert` method. 
2. `FlatfileClient` now refers to the new `RecordsClient` instead of the default one. 

