### PR TITLE
:herb: publish rc versions with `--tag rc`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -6,3 +6,4 @@ LICENSE.txt
 src/wrapper
 src/index.ts
 
+.github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm publish --access public
+          VERSION=$(cat package.json | jq -r '.version')
+          if [[ $VERSION == *"rc"* ]]; then
+            npm publish --access public --tag rc
+          else
+            npm publish --access public
+          fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR modifies the Fern-generated github workflow to pulblish rc versions on a specific npm track.