### PR TITLE
chore: remove Fetcher from fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -5,6 +5,5 @@ LICENSE.txt
 
 src/wrapper
 src/index.ts
-src/core/fetcher/Fetcher.ts
 
 .github/workflows/ci.yml


### PR DESCRIPTION
Fern's latest release applies the fix to support gzipped requests that we overrode in Fetcher. This PR removes Fetcher from .fernignore and updates the Fern generator version.