### PR TITLE
(fix): `RecordsClient` doesn't depend on root index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flatfile/api",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "private": false,
     "repository": "https://github.com/FlatFilers/flatfile-node",
     "main": "./index.js",

--- a/src/wrapper/RecordsClient.ts
+++ b/src/wrapper/RecordsClient.ts
@@ -1,6 +1,6 @@
 import pako from "pako";
 import urlJoin from "url-join";
-import { Flatfile } from "..";
+import * as Flatfile from "../api/index";
 import { Records as FernRecords } from "../api/resources/records/client/Client";
 import * as core from "../core";
 import * as environments from "../environments";


### PR DESCRIPTION
Because `RecordsClient` now imports types from `./src/api` it will no longer conflict with the default import in the top level index. 