### PR TITLE
Remove ci install

### DIFF
--- a/.github/workflows/cl-create.yml
+++ b/.github/workflows/cl-create.yml
@@ -19,9 +19,6 @@ jobs:
 
       - name: Authenticate with private NPM package
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
-        
-      - name: Install dependencies
-        run: npm ci
 
       - name: Install changelog
         run: npm i @flatfile/changelog --save-optional


### PR DESCRIPTION
`npm ci` fails because there is no package-lock.json.

Since the only dep we need for this action isn't in the package.json and is installed in the next step anyone, this just removes it.