### PR TITLE
Resolve a Type conflict on FlatfileClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
+      - name: Run tests
+        uses: npm run test
+
       - name: Compile
         run: yarn && yarn build
   

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,6 @@
 tabWidth: 4
 printWidth: 120
+overrides: 
+  - files: "*.yml",
+    options:
+      tabWidth: 2

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -32,14 +32,14 @@ import { Versions } from "./api/resources/versions/client/Client";
 import { Views } from "./api/resources/views/client/Client";
 import { Workbooks } from "./api/resources/workbooks/client/Client";
 
-export declare namespace FlatfileClient {
-    interface Options {
+export namespace FlatfileClient {
+    export interface Options {
         environment?: core.Supplier<environments.FlatfileEnvironment | string>;
         token?: core.Supplier<core.BearerToken | undefined>;
         fetcher?: core.FetchFunction;
     }
 
-    interface RequestOptions {
+    export interface RequestOptions {
         timeoutInSeconds?: number;
         maxRetries?: number;
     }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,11 +1,9 @@
-/**
-* This is a test file for the SDK.
-* 
-* Add any tests here and make sure to mark this file
-* in `.fernignore`. 
-*/
-describe("test", () => {
-    it("default", () => {
-        expect(true).toBe(true);
-    });
+import { FlatfileClient } from "../src/Client";
+
+describe("FlatfileClient", () => {
+  it("is instantiatable as a class", () => {
+    const client = new FlatfileClient();
+
+    expect(client).toBeInstanceOf(FlatfileClient);
+  });
 });


### PR DESCRIPTION
Currently we have a conflict between the `FlatfileClient` type namespace and the class itself. If you try to instantiate a `FlatfileClient` object, you will get the following error:

```
Type 'typeof FlatfileClient' has no construct signatures.

  const client = new FlatfileClient();
```

I've also added a Jest test that will fail if this regresses in the future.