### PR TITLE
Output package versions for debugging

### DIFF
--- a/.github/workflows/cl-create.yml
+++ b/.github/workflows/cl-create.yml
@@ -30,7 +30,10 @@ jobs:
   
           echo "DESTINATION_REPO=${destinationRepo}" >> $GITHUB_ENV
           echo "DESTINATION_DIRECTORY=${destinationDirectory}" >> $GITHUB_ENV
-  
+
+      - name: Print all git tags
+        run: npm view @flatfile/api versions --json
+
       - name: Create a changelog update
         run: npx changelog generate tag ${{ github.event.release.tag_name }}
         env:


### PR DESCRIPTION
For the change log action generating a diff from the release tag requires being able to list the other tags to select the previous release. This checks the output of that command since the previous version is presently undefined when the action runs.