### PR TITLE
Fix/api url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flatfile/api",
-    "version": "1.9.19-rc.0",
+    "version": "1.9.18",
     "private": false,
     "repository": "https://github.com/FlatFilers/flatfile-node",
     "main": "./index.js",
@@ -31,6 +31,5 @@
         "@types/node": "17.0.33",
         "prettier": "2.7.1",
         "typescript": "4.6.4"
-    },
-    "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
         "@types/node": "17.0.33",
         "prettier": "2.7.1",
         "typescript": "4.6.4"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flatfile/api",
-    "version": "1.9.18",
+    "version": "1.9.19-rc.0",
     "private": false,
     "repository": "https://github.com/FlatFilers/flatfile-node",
     "main": "./index.js",

--- a/src/wrapper/FlatfileClient.ts
+++ b/src/wrapper/FlatfileClient.ts
@@ -24,7 +24,7 @@ export class FlatfileClient extends FernClient {
 
     constructor(options: FlatfileClient.Options = {}) {
         super({
-            environment: resolveEnvironment(options),
+            environment: resolveEnvironment(options) ?? environmentSupplier,
             token: options.token ?? tokenSupplier,
         });
     }
@@ -40,7 +40,7 @@ const resolveEnvironment = (options: FlatfileClient.Options) => {
     if (options.apiUrl && !options.apiUrl.endsWith("/v1")) {
         return urlJoin(options.apiUrl, "v1");
     }
-    return options.environment || options.apiUrl || environmentSupplier();
+    return options.environment || options.apiUrl;
 };
 
 const environmentSupplier = () => {


### PR DESCRIPTION
This fixes an issue where the `apiUrl` / `environment` value was stored permanently in the `FlatfileClient` instead of re-fetching the value from the env values